### PR TITLE
Allows presenting SFSafariViewController when the rootViewController is already presenting another view controller

### DIFF
--- a/Sources/BetterSafariView/SafariView/SafariViewPresenter.swift
+++ b/Sources/BetterSafariView/SafariView/SafariViewPresenter.swift
@@ -73,10 +73,10 @@ extension SafariViewPresenter {
         // MARK: Presentation Handlers
         
         private func presentSafariViewController(with item: Item) {
-			guard uiViewController.presentedViewController == nil else {
-				return
-			}
-			
+            guard uiViewController.presentedViewController == nil else {
+                return
+            }
+            
             let representation = parent.representationBuilder(item)
             let safariViewController = SFSafariViewController(url: representation.url, configuration: representation.configuration)
             safariViewController.delegate = self
@@ -85,8 +85,8 @@ extension SafariViewPresenter {
             // There is a problem that page loading and parallel push animation are not working when a modifier is attached to the view in a `List`.
             // As a workaround, use a `rootViewController` of the `window` for presenting.
             // (Unlike the other view controllers, a view controller hosted by a cell doesn't have a parent, but has the same window.)
-			var presentingViewController = uiViewController.view.window?.rootViewController
-			presentingViewController = presentingViewController?.presentedViewController ?? presentingViewController ?? uiViewController
+            var presentingViewController = uiViewController.view.window?.rootViewController
+            presentingViewController = presentingViewController?.presentedViewController ?? presentingViewController ?? uiViewController
             presentingViewController?.present(safariViewController, animated: true)
         }
         
@@ -99,22 +99,22 @@ extension SafariViewPresenter {
         }
         
         private func dismissSafariViewController(completion: (() -> Void)? = nil) {
-			let dismissCompletion: () -> Void = {
-				self.handleDismissalWithoutResettingItemBinding()
-				completion?()
-			}
-			
-			guard uiViewController.presentedViewController != nil else {
-				dismissCompletion()
-				return
-			}
+            let dismissCompletion: () -> Void = {
+                self.handleDismissalWithoutResettingItemBinding()
+                completion?()
+            }
+            
+            guard uiViewController.presentedViewController != nil else {
+                dismissCompletion()
+                return
+            }
             
             // Check if the `uiViewController` is a instance of the `SFSafariViewController`
             // to prevent other controllers presented by the container view from being dismissed unintentionally.
-			guard let safariViewController = uiViewController.presentedViewController as? SFSafariViewController else {
+            guard let safariViewController = uiViewController.presentedViewController as? SFSafariViewController else {
                 return
             }
-			safariViewController.dismiss(animated: true, completion: dismissCompletion)
+            safariViewController.dismiss(animated: true, completion: dismissCompletion)
         }
         
         // MARK: Dismissal Handlers

--- a/Sources/BetterSafariView/SafariView/SafariViewPresenter.swift
+++ b/Sources/BetterSafariView/SafariView/SafariViewPresenter.swift
@@ -73,6 +73,10 @@ extension SafariViewPresenter {
         // MARK: Presentation Handlers
         
         private func presentSafariViewController(with item: Item) {
+			guard uiViewController.presentedViewController == nil else {
+				return
+			}
+			
             let representation = parent.representationBuilder(item)
             let safariViewController = SFSafariViewController(url: representation.url, configuration: representation.configuration)
             safariViewController.delegate = self
@@ -81,8 +85,9 @@ extension SafariViewPresenter {
             // There is a problem that page loading and parallel push animation are not working when a modifier is attached to the view in a `List`.
             // As a workaround, use a `rootViewController` of the `window` for presenting.
             // (Unlike the other view controllers, a view controller hosted by a cell doesn't have a parent, but has the same window.)
-            let presentingViewController = uiViewController.view.window?.rootViewController ?? uiViewController
-            presentingViewController.present(safariViewController, animated: true)
+			var presentingViewController = uiViewController.view.window?.rootViewController
+			presentingViewController = presentingViewController?.presentedViewController ?? presentingViewController ?? uiViewController
+            presentingViewController?.present(safariViewController, animated: true)
         }
         
         private func updateSafariViewController(with item: Item) {

--- a/Sources/BetterSafariView/SafariView/SafariViewPresenter.swift
+++ b/Sources/BetterSafariView/SafariView/SafariViewPresenter.swift
@@ -94,16 +94,22 @@ extension SafariViewPresenter {
         }
         
         private func dismissSafariViewController(completion: (() -> Void)? = nil) {
+			let dismissCompletion: () -> Void = {
+				self.handleDismissalWithoutResettingItemBinding()
+				completion?()
+			}
+			
+			guard uiViewController.presentedViewController != nil else {
+				dismissCompletion()
+				return
+			}
             
             // Check if the `uiViewController` is a instance of the `SFSafariViewController`
             // to prevent other controllers presented by the container view from being dismissed unintentionally.
             guard uiViewController.presentedViewController is SFSafariViewController else {
                 return
             }
-            uiViewController.dismiss(animated: true) {
-                self.handleDismissalWithoutResettingItemBinding()
-                completion?()
-            }
+            uiViewController.dismiss(animated: true, completion: dismissCompletion)
         }
         
         // MARK: Dismissal Handlers

--- a/Sources/BetterSafariView/SafariView/SafariViewPresenter.swift
+++ b/Sources/BetterSafariView/SafariView/SafariViewPresenter.swift
@@ -111,10 +111,10 @@ extension SafariViewPresenter {
             
             // Check if the `uiViewController` is a instance of the `SFSafariViewController`
             // to prevent other controllers presented by the container view from being dismissed unintentionally.
-            guard uiViewController.presentedViewController is SFSafariViewController else {
+			guard let safariViewController = uiViewController.presentedViewController as? SFSafariViewController else {
                 return
             }
-            uiViewController.dismiss(animated: true, completion: dismissCompletion)
+			safariViewController.dismiss(animated: true, completion: dismissCompletion)
         }
         
         // MARK: Dismissal Handlers


### PR DESCRIPTION
The main commit fixes the issue reported at https://github.com/stleamist/BetterSafariView/issues/8

The other commit fixes a weird case (difficult to replicate) when dismissSafariViewController is called but uiViewController is not presenting.