### PR TITLE
Fixes Unexpectedly Found Nil When Unwrapping Optional in WebAuthentic…

### DIFF
--- a/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresenter.swift
+++ b/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresenter.swift
@@ -179,7 +179,7 @@ extension WebAuthenticationPresenter {
             // MARK: ASWebAuthenticationPresentationContextProviding
             
             func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-                return coordinator.view.window!
+                return coordinator.view.window ?? ASPresentationAnchor()
             }
         }
         


### PR DESCRIPTION
…ationPresenter

This pull request fixes the unexpectedly found nil when unwrapping optional by using ASPresentationAnchor() for iOS 13+ and MacOS 10.15+, otherwise defaults to original behavior.