### PR TITLE
Fixes Unexpectedly Found Nil When Unwrapping Optional in WebAuthenticationPresenter

### DIFF
--- a/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresenter.swift
+++ b/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresenter.swift
@@ -179,7 +179,7 @@ extension WebAuthenticationPresenter {
             // MARK: ASWebAuthenticationPresentationContextProviding
             
             func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
-                return coordinator.view.window!
+                return coordinator.view.window ?? ASPresentationAnchor()
             }
         }
         


### PR DESCRIPTION
This was being [worked on](https://github.com/stleamist/BetterSafariView/pull/22) but seems to have stalled out. So I am creating a new PR to hopefully finish it out.