### PR TITLE
[iOS 17] Fix navigation to safari not working when keyboard is visible

### DIFF
--- a/Demo/iOS/Views/RootView.swift
+++ b/Demo/iOS/Views/RootView.swift
@@ -16,7 +16,9 @@ struct RootView: View {
     @State private var showingWebAuthenticationSessionOptionsForm = false
     
     @State private var webAuthenticationSessionCallbackURL: URL? = nil
-    
+
+    @State private var text = ""
+
     var body: some View {
         NavigationView {
             List {
@@ -73,7 +75,9 @@ struct RootView: View {
                         WebAuthenticationSessionOptionsForm(options: $webAuthenticationSessionOptions)
                     }
                 }
-                
+
+                TextField("Text field", text: $text)
+
                 Section(header: Text("NaiveSafariView" + "\n" + "(Just for comparison. Do not use in practice.)").textCase(nil)) {
                     Button(action: { showingNaiveSafariViewSheet = true }) {
                         HStack {

--- a/Sources/BetterSafariView/Shared/UIView+viewController.swift
+++ b/Sources/BetterSafariView/Shared/UIView+viewController.swift
@@ -2,15 +2,15 @@
 
 import UIKit
 
-extension UIView {
-    
+extension UIResponder {
+
     /// The receiver’s view controller, or `nil` if it has none.
     ///
     /// This property is `nil` if the view has not yet been added to a view controller.
     var viewController: UIViewController? {
         if let nextResponder = self.next as? UIViewController {
             return nextResponder
-        } else if let nextResponder = self.next as? UIView {
+        } else if let nextResponder = self.next {
             return nextResponder.viewController
         } else {
             return nil


### PR DESCRIPTION
iOS 17 adds SwiftUI.UIKitKeyPressResponder to responder chain between inserted UIView and first UIViewController which is neither an UIView or UIViewController. This caused the search for UIViewController to fail before fix.