### PR TITLE
Fix: non-main thread issue when closing WebAuthenticationSession

### DIFF
--- a/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresenter.swift
+++ b/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresenter.swift
@@ -155,7 +155,9 @@ extension WebAuthenticationPresenter {
         // MARK: Dismissal Handlers
         
         private func resetItemBinding() {
-            parent.item = nil
+            DispatchQueue.main.async {
+                self.parent.item = nil
+            }
         }
         
         #if os(iOS) || os(macOS)


### PR DESCRIPTION
Hello 👋

I found a problem when using `WebAuthenticationSession` in a project that uses [TCA framework](https://github.com/pointfreeco/swift-composable-architecture)

### Problem:

A **non-main thread issue occurs** when closing the `WebAuthenticationSession` window.

(Warnings generated by the TCA library)
<img width="1036" alt="스크린샷 2023-09-06 오후 3 10 37" src="https://github.com/stleamist/BetterSafariView/assets/13725729/3a13b00f-50dd-4604-9c4b-49efa25ee393">

(Warnings generated by the SwiftUI Framework)
<img width="744" alt="스크린샷 2023-09-06 오후 3 11 07" src="https://github.com/stleamist/BetterSafariView/assets/13725729/e39834a8-bf39-4de8-85d6-6682caecf7ca">


### Cause:

The problem does not occur when using the pure SwiftUI `@Binding`. However, when assigning a Binding variable to `isPresented:` using `TCA`, it appears that the action of the Binding variable becoming false **when the window closes is executed in the background.** (This is just a guess of mine, so it may be wrong.)

Anyway, the problem occurs when the value of the variable `item` is changeed to `nil` inside the `completionHandler` of the `WebAuthenticationPresenter`.


### Solution:

This commit is modified to **run on the main thread** in the `resetItemBinding()` function.
```diff
private func resetItemBinding() {
-    parent.item = nil
+    DispatchQueue.main.async {
+        self.parent.item = nil
+    }
}
```

### Testing:

I confirmed that this modification does not cause side effects when using pure SwiftUI.

### Request:

Please let me know if there is a possibility that another problem may occur due to this modification. If not, please reflect it in the main branch.

Thank you for your time.
Have a nice day.


---
---
---

안녕하세요. 영어로 번역하는 과정에서 의도가 정확히 전달되지 않은 부분이 있을 것 같아, 한국어로 요약한 내용도 함께 기재합니다.

TCA를 사용하는 프로젝트에서 `WebAuthenticationSession`을 사용할 때, 다음과 같은 문제가 발생하는 것을 알게 되었습니다.

### 문제 : 
`WebAuthenticationSession` 창이 닫힐 때, non-main thread 관련 문제 발생.
(이미지 생략)

### 원인 파악 :
순수한 SwiftUI의 `@Binding`을 이용하였을 때는 문제가 없었습니다.
하지만 TCA를 사용하여 `isPresented:`에 Binding 변수를 할당하게 되면 창이 닫히면서 Binding 변수가 false로 변하는 동작이 background에서 실행이 되는 것으로 보입니다. (추측이므로, 틀렸을 수도 있음.)

어쨌든, 문제가 발생하는 시점은 `WebAuthenticationPresenter`의 `completionHandler`의 동작 내부에서 변수 `item`의 값을 `nil`로 초기화 할 때인 것으로 확인했습니다.

### 해결 방안 제시 :
`resetItemBinding()` 함수 내부의 코드를 main thread에서 동작하도록 수정.

---

이 수정은 순수하게 SwiftUI를 사용하는 경우에 대해 side effect를 발생시키지 않는것으로 확인했습니다.
만약 이 수정으로 인해 제가 모르는 또 다른 문제가 발생할 가능성이 있다면 알려주시고, 그렇지 않다면 main branch에 반영시켜주시기를 부탁드립니다.

고맙습니다.
좋은 하루 보내세요.