### PR TITLE
Adding UIColor variants of preferred color methods

### DIFF
--- a/Sources/BetterSafariView/SafariView/SafariView.swift
+++ b/Sources/BetterSafariView/SafariView/SafariView.swift
@@ -72,15 +72,29 @@ public struct SafariView {
     ///
     @available(iOS 14.0, *)
     public func preferredBarAccentColor(_ color: Color?) -> Self {
+        guard let color else { return self }
+
+        return self.preferredControlAccentColor(UIColor(color))
+    }
+
+    /// Sets the accent color for the background of the navigation bar and the toolbar.
+    ///
+    /// This color preference is ignored if the view controller is in Private Browsing mode or displaying an antiphishing warning.
+    /// After the view controller is presented, changes made are not reflected.
+    ///
+    /// - Parameters:
+    ///     - color: The color to use as a bar accent color. If `nil`, the accent color continues to be inherited.
+    ///
+    public func preferredBarAccentColor(_ color: UIColor?) -> Self {
         var modified = self
         if let color = color {
-            modified.preferredBarTintColor = UIColor(color)
+            modified.preferredBarTintColor = color
         } else {
             modified.preferredBarTintColor = nil
         }
         return modified
     }
-    
+
     /// Sets the accent color for the control buttons on the navigation bar and the toolbar.
     ///
     /// This color preference is ignored if the view controller is in Private Browsing mode or displaying an antiphishing warning.
@@ -91,9 +105,24 @@ public struct SafariView {
     ///
     @available(iOS 14.0, *)
     public func preferredControlAccentColor(_ color: Color?) -> Self {
+        guard let color else { return self }
+
+        return self.preferredControlAccentColor(UIColor(color))
+    }
+
+    /// Sets the accent color for the control buttons on the navigation bar and the toolbar.
+    ///
+    /// This color preference is ignored if the view controller is in Private Browsing mode or displaying an antiphishing warning.
+    /// After the view controller is presented, changes made are not reflected.
+    ///
+    /// - Parameters:
+    ///     - color: The color to use as a control accent color. If `nil`, the accent color continues to be inherited.
+    ///
+    @available(iOS 14.0, *)
+    public func preferredControlAccentColor(_ color: UIColor?) -> Self {
         var modified = self
         if let color = color {
-            modified.preferredControlTintColor = UIColor(color)
+            modified.preferredControlTintColor = color
         } else {
             modified.preferredControlTintColor = nil
         }


### PR DESCRIPTION
There is a bug where the conversion of `UIColor(Color)` does not respect dark/light mode properly, the conversion is lossy with respect to color scheme. I’ve added a small helper that handles this properly, with a safe fallback to `UIColor(Color)` in the very unlikely event that asset catalog formats change in the future.

#### Dark Mode Before
![image](https://github.com/stleamist/BetterSafariView/assets/716513/b0c2be0f-56de-4ef6-b69e-5cd9e3c08200)

#### Dark Mode After
![image](https://github.com/stleamist/BetterSafariView/assets/716513/5d6430a1-5fe0-4049-9aaa-695b66204cc9)