### PR TITLE
Add visionOS support

### DIFF
--- a/Demo/BetterSafariViewDemo.xcodeproj/project.pbxproj
+++ b/Demo/BetterSafariViewDemo.xcodeproj/project.pbxproj
@@ -3,10 +3,15 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0A0AFFE42CA8202900A139BD /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71240112524CF69001A648E /* Constants.swift */; };
+		0A0AFFE62CA820DF00A139BD /* BetterSafariView in Frameworks */ = {isa = PBXBuildFile; productRef = 0A0AFFE52CA820DF00A139BD /* BetterSafariView */; };
+		0A0AFFF72CA82D7E00A139BD /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0AFFF22CA82CEC00A139BD /* ContentView.swift */; };
+		0A0AFFF82CA82D7E00A139BD /* MainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A0AFFF42CA82CEC00A139BD /* MainView.swift */; };
+		0A0AFFF92CA82EE100A139BD /* WebAuthenticationSessionOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71240182524CF71001A648E /* WebAuthenticationSessionOptions.swift */; };
 		C71240082524CF40001A648E /* SafariViewOptionsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71240002524CF40001A648E /* SafariViewOptionsForm.swift */; };
 		C71240092524CF40001A648E /* WebAuthenticationSessionOptionsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71240012524CF40001A648E /* WebAuthenticationSessionOptionsForm.swift */; };
 		C712400A2524CF40001A648E /* NaiveSafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71240022524CF40001A648E /* NaiveSafariView.swift */; };
@@ -67,6 +72,9 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		0A0AFFCA2CA81F2E00A139BD /* BetterSafariViewDemo (visionOS).app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "BetterSafariViewDemo (visionOS).app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		0A0AFFF22CA82CEC00A139BD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		0A0AFFF42CA82CEC00A139BD /* MainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainView.swift; sourceTree = "<group>"; };
 		C71240002524CF40001A648E /* SafariViewOptionsForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SafariViewOptionsForm.swift; sourceTree = "<group>"; };
 		C71240012524CF40001A648E /* WebAuthenticationSessionOptionsForm.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebAuthenticationSessionOptionsForm.swift; sourceTree = "<group>"; };
 		C71240022524CF40001A648E /* NaiveSafariView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NaiveSafariView.swift; sourceTree = "<group>"; };
@@ -95,6 +103,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		0A0AFFC72CA81F2E00A139BD /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A0AFFE62CA820DF00A139BD /* BetterSafariView in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7BA0FF92525D4A9002BC9F7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -122,6 +138,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0A0AFFF52CA82CEC00A139BD /* visionOS */ = {
+			isa = PBXGroup;
+			children = (
+				0A0AFFF22CA82CEC00A139BD /* ContentView.swift */,
+				0A0AFFF42CA82CEC00A139BD /* MainView.swift */,
+			);
+			path = visionOS;
+			sourceTree = "<group>";
+		};
 		C7123FFE2524CF40001A648E /* Views */ = {
 			isa = PBXGroup;
 			children = (
@@ -201,6 +226,7 @@
 				C7EFD51F2524CED800A08BEA /* macOS */,
 				C7BA0FF42525D4A7002BC9F7 /* watchOS */,
 				C7BA10002525D4A9002BC9F7 /* watchOS Extension */,
+				0A0AFFF52CA82CEC00A139BD /* visionOS */,
 				C7EFD5172524CED800A08BEA /* Products */,
 				C71240212524CFAB001A648E /* Frameworks */,
 			);
@@ -226,6 +252,7 @@
 				C7EFD51E2524CED800A08BEA /* BetterSafariViewDemo.app */,
 				C7BA0FF02525D4A7002BC9F7 /* BetterSafariViewDemo.app */,
 				C7BA0FFC2525D4A9002BC9F7 /* BetterSafariViewDemo Extension.appex */,
+				0A0AFFCA2CA81F2E00A139BD /* BetterSafariViewDemo (visionOS).app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -252,6 +279,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		0A0AFFC92CA81F2E00A139BD /* BetterSafariViewDemo (visionOS) */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0A0AFFD92CA81F2F00A139BD /* Build configuration list for PBXNativeTarget "BetterSafariViewDemo (visionOS)" */;
+			buildPhases = (
+				0A0AFFC62CA81F2E00A139BD /* Sources */,
+				0A0AFFC72CA81F2E00A139BD /* Frameworks */,
+				0A0AFFC82CA81F2E00A139BD /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "BetterSafariViewDemo (visionOS)";
+			packageProductDependencies = (
+				0A0AFFE52CA820DF00A139BD /* BetterSafariView */,
+			);
+			productName = "BetterSafariViewDemo (visionOS)";
+			productReference = 0A0AFFCA2CA81F2E00A139BD /* BetterSafariViewDemo (visionOS).app */;
+			productType = "com.apple.product-type.application";
+		};
 		C7BA0FEF2525D4A7002BC9F7 /* BetterSafariViewDemo (watchOS) */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = C7BA10162525D4AA002BC9F7 /* Build configuration list for PBXNativeTarget "BetterSafariViewDemo (watchOS)" */;
@@ -335,9 +382,12 @@
 		C7EFD50A2524CED600A08BEA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1220;
+				LastSwiftUpdateCheck = 1600;
 				LastUpgradeCheck = 1220;
 				TargetAttributes = {
+					0A0AFFC92CA81F2E00A139BD = {
+						CreatedOnToolsVersion = 16.0;
+					};
 					C7BA0FEF2525D4A7002BC9F7 = {
 						CreatedOnToolsVersion = 12.2;
 					};
@@ -369,11 +419,19 @@
 				C7EFD51D2524CED800A08BEA /* BetterSafariViewDemo (macOS) */,
 				C7BA0FEF2525D4A7002BC9F7 /* BetterSafariViewDemo (watchOS) */,
 				C7BA0FFB2525D4A9002BC9F7 /* BetterSafariViewDemo (watchOS Extension) */,
+				0A0AFFC92CA81F2E00A139BD /* BetterSafariViewDemo (visionOS) */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		0A0AFFC82CA81F2E00A139BD /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7BA0FEE2525D4A7002BC9F7 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -409,6 +467,17 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		0A0AFFC62CA81F2E00A139BD /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0A0AFFF92CA82EE100A139BD /* WebAuthenticationSessionOptions.swift in Sources */,
+				0A0AFFF72CA82D7E00A139BD /* ContentView.swift in Sources */,
+				0A0AFFF82CA82D7E00A139BD /* MainView.swift in Sources */,
+				0A0AFFE42CA8202900A139BD /* Constants.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		C7BA0FF82525D4A9002BC9F7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -466,10 +535,75 @@
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		0A0AFFDA2CA81F2F00A139BD /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSBackgroundOnly = NO;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stleam.BetterSafariViewDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Debug;
+		};
+		0A0AFFDB2CA81F2F00A139BD /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = "";
+				ENABLE_PREVIEWS = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_KEY_LSBackgroundOnly = NO;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.stleam.BetterSafariViewDemo;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = xros;
+				SUPPORTED_PLATFORMS = "xros xrsimulator";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 7;
+				VALIDATE_PRODUCT = YES;
+				XROS_DEPLOYMENT_TARGET = 2.0;
+			};
+			name = Release;
+		};
 		C7BA10102525D4AA002BC9F7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-watchOS";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -491,7 +625,6 @@
 		C7BA10112525D4AA002BC9F7 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = "AppIcon-watchOS";
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -691,9 +824,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stleam.BetterSafariViewDemo;
 				PRODUCT_NAME = BetterSafariViewDemo;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 			};
 			name = Debug;
 		};
@@ -717,9 +852,11 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stleam.BetterSafariViewDemo;
 				PRODUCT_NAME = BetterSafariViewDemo;
 				SDKROOT = iphoneos;
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator xros xrsimulator";
 				SUPPORTS_MACCATALYST = YES;
+				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
+				TARGETED_DEVICE_FAMILY = "1,2,7";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -779,6 +916,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0A0AFFD92CA81F2F00A139BD /* Build configuration list for PBXNativeTarget "BetterSafariViewDemo (visionOS)" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				0A0AFFDA2CA81F2F00A139BD /* Debug */,
+				0A0AFFDB2CA81F2F00A139BD /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		C7BA10152525D4AA002BC9F7 /* Build configuration list for PBXNativeTarget "BetterSafariViewDemo (watchOS Extension)" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -827,6 +973,10 @@
 /* End XCConfigurationList section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		0A0AFFE52CA820DF00A139BD /* BetterSafariView */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = BetterSafariView;
+		};
 		C71240222524CFAB001A648E /* BetterSafariView */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = BetterSafariView;

--- a/Demo/Shared/Options/WebAuthenticationSessionOptionsForm.swift
+++ b/Demo/Shared/Options/WebAuthenticationSessionOptionsForm.swift
@@ -23,7 +23,7 @@ struct WebAuthenticationSessionOptionsForm: View {
                 Section(header: Text("URL")) {
                     TextField(gitHubAuthorizationURLString, text: $temporaryOptions.urlString)
                         .modify {
-                            #if os(iOS)
+                            #if os(iOS) || os(visionOS)
                             $0
                                 .textContentType(.URL)
                                 .keyboardType(.URL)

--- a/Demo/visionOS/ContentView.swift
+++ b/Demo/visionOS/ContentView.swift
@@ -1,0 +1,70 @@
+//
+import AuthenticationServices
+import BetterSafariView
+import SwiftUI
+
+struct ContentView: View {
+  @State private var webAuthenticationSessionOptions = WebAuthenticationSessionOptions()
+  @State private var showingWebAuthenticationSession = false
+  @State private var webAuthenticationSessionCallbackURL: URL? = nil
+
+  private var urlIsInvalid: Bool {
+    (webAuthenticationSessionOptions.url == nil) || !["http", "https"].contains(webAuthenticationSessionOptions.url?.scheme)
+  }
+
+  var body: some View {
+    VStack(alignment: .trailing) {
+      GroupBox(label: Text("WebAuthenticationSession")) {
+        VStack {
+          HStack {
+            Text("URL:")
+            TextField(gitHubAuthorizationURLString, text: $webAuthenticationSessionOptions.urlString)
+          }
+          HStack {
+            Text("Callback URL Scheme:")
+            TextField(gitHubAuthorizationURLString, text: $webAuthenticationSessionOptions.callbackURLScheme)
+          }
+          HStack {
+            Text("Modifiers:")
+            Toggle("Ephemeral Session", isOn: $webAuthenticationSessionOptions.prefersEphemeralWebBrowserSession)
+          }
+          Spacer()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+      }
+      Button(action: { showingWebAuthenticationSession = true }) {
+        Text("Start Session")
+      }
+      .keyboardShortcut(.defaultAction)
+      .disabled(urlIsInvalid)
+      // Capture `webAuthenticationSessionOptions` to fix an issue
+      // where SwiftUI doesn't pass the latest value to the modifier.
+      // https://developer.apple.com/documentation/swiftui/view/onchange(of:perform:)
+      .webAuthenticationSession(
+        isPresented: $showingWebAuthenticationSession
+      ) { [webAuthenticationSessionOptions] in
+        WebAuthenticationSession(
+          url: webAuthenticationSessionOptions.url!,
+          callbackURLScheme: webAuthenticationSessionOptions.callbackURLScheme
+        ) { callbackURL, error in
+          webAuthenticationSessionCallbackURL = callbackURL
+        }
+        .prefersEphemeralWebBrowserSession(webAuthenticationSessionOptions.prefersEphemeralWebBrowserSession)
+      }
+      .alert(item: $webAuthenticationSessionCallbackURL) { callbackURL in
+        Alert(
+          title: Text("Session Completed with Callback URL"),
+          message: Text(callbackURL.absoluteString),
+          dismissButton: nil
+        )
+      }
+    }
+    .padding(40)
+    .toolbar {
+      ToolbarItem(placement: .automatic) {
+        Spacer()
+      }
+    }
+  }
+}

--- a/Demo/visionOS/MainView.swift
+++ b/Demo/visionOS/MainView.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MainView: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresentationModifier.swift
+++ b/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresentationModifier.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(visionOS)
 
 import SwiftUI
 

--- a/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresenter.swift
+++ b/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationPresenter.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(visionOS)
 
 import SwiftUI
 import AuthenticationServices
@@ -6,7 +6,7 @@ import AuthenticationServices
 import SafariServices
 #endif
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 typealias ViewType = UIView
 typealias ViewRepresentableType = UIViewRepresentable
 #elseif os(macOS)
@@ -32,8 +32,8 @@ struct WebAuthenticationPresenter<Item: Identifiable>: ViewRepresentableType {
         return Coordinator(parent: self)
     }
     
-    #if os(iOS)
-    
+    #if os(iOS) || os(visionOS)
+
     func makeUIView(context: Context) -> ViewType {
         return makeView(context: context)
     }
@@ -45,10 +45,14 @@ struct WebAuthenticationPresenter<Item: Identifiable>: ViewRepresentableType {
         // To set a delegate for the presentation controller of an `SFAuthenticationViewController` as soon as possible,
         // check the view controller presented by `view.viewController` then set it as a delegate on every view updates.
         // INFO: `SFAuthenticationViewController` is a private subclass of `SFSafariViewController`.
-        guard #available(iOS 14.0, *) else {
+
+
+      #if os(iOS)
+      guard #available(iOS 14.0, *) else {
             context.coordinator.setInteractiveDismissalDelegateIfPossible()
             return
         }
+      #endif
     }
     
     #elseif os(macOS)
@@ -137,7 +141,7 @@ extension WebAuthenticationPresenter {
                 }
             )
             
-            #if os(iOS) || os(macOS)
+            #if os(iOS) || os(macOS) || os(visionOS)
             session.presentationContextProvider = presentationContextProvider
             #endif
             
@@ -158,8 +162,8 @@ extension WebAuthenticationPresenter {
             parent.item = nil
         }
         
-        #if os(iOS) || os(macOS)
-        
+        #if os(iOS) || os(macOS) || os(visionOS)
+
         // MARK: PresentationContextProvider
         
         // INFO: `ASWebAuthenticationPresentationContextProviding` provides an window

--- a/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationSession.swift
+++ b/Sources/BetterSafariView/WebAuthenticationSession/WebAuthenticationSession.swift
@@ -1,4 +1,4 @@
-#if os(iOS) || os(macOS) || os(watchOS)
+#if os(iOS) || os(macOS) || os(watchOS) || os(visionOS)
 
 import SwiftUI
 import AuthenticationServices


### PR DESCRIPTION
visionOS seems to work just like iOS with regards to UIViewRepresentable, so this mostly just allows it and adds a native visionOS demo app.